### PR TITLE
Improve toplev run header output

### DIFF
--- a/toplev.py
+++ b/toplev.py
@@ -2059,9 +2059,11 @@ def execute_no_multiplex(runner_list, out, rest, summary):
             if gg.outgroup:
                 outg.append(g)
                 continue
+            if n > 0:
+                print()
             print("RUN #%d of %d%s: %s" % (n + 1, num_runs,
                 " for %s" % runner_name(runner) if len(runner_list) > 1 else "",
-                " ".join([quote(o.name) for o in gg.objl])))
+                " ".join([quote(o.name) for o in gg.objl])), flush=True)
             # becomes results for first iteration
             lresults = results if n == 0 else []
             res = None


### PR DESCRIPTION
## Summary
- flush run header printing and add blank lines between runs

## Testing
- `./FLAKE8`
- `./MYPY`
- `shellcheck  -e SC2086,SC2012 -x tl-tester tester other-tester parallel-tester all-tester jevents/tester  ucevent/uctester`
- `WRAP=python PERF=./fake-perf.py NORES=1 ./tl-tester`
- `WRAP=python PERF=./fake-perf.py NORES=1 ./tester`
- `WRAP=python PERF=./fake-perf.py NORES=1 ./other-tester`
- `cd ucevent && for i in jkt ivt hsx bdxde bdx skx ; do FORCECPU=$i WRAP=python MOCK=1 NORES=1 ./uctester ; done`
- `cd parser && ./tester`

------
https://chatgpt.com/codex/tasks/task_e_6851e8029098832c8261685b247aa685